### PR TITLE
make ssl configurable

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,9 @@
 {
   "host": "localhost",
   "port": 443,
+  "key": "/etc/letsencrypt/live/angelthump.com/privkey.pem",
+  "cert": "/etc/letsencrypt/live/angelthump.com/cert.pem",
+  "ca": "/etc/letsencrypt/live/angelthump.com/fullchain.pem",
   "public": "../public/",
   "mongodb": "mongodb://localhost:27017/feathers",
   "auth": {

--- a/config/production.json
+++ b/config/production.json
@@ -1,6 +1,9 @@
 {
   "host": "feathers-chat-app.feathersjs.com",
   "port": 80,
+  "key": "/etc/letsencrypt/live/angelthump.com/privkey.pem",
+  "cert": "/etc/letsencrypt/live/angelthump.com/cert.pem",
+  "ca": "/etc/letsencrypt/live/angelthump.com/fullchain.pem",
   "nedb": "NEDB_BASE_PATH",
   "public": "../public/",
   "auth": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,28 @@
 'use strict';
 
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+const path = require('path');
+
 const app = require('./app');
 const port = app.get('port');
 
-const fs = require('fs');
-const https  = require('https');
+let server;
 
-const server = https.createServer({
-  key: fs.readFileSync('/etc/letsencrypt/live/angelthump.com/privkey.pem'),
-  cert: fs.readFileSync('/etc/letsencrypt/live/angelthump.com/cert.pem'),
-  ca: fs.readFileSync('/etc/letsencrypt/live/angelthump.com/fullchain.pem')
-}, app).listen(port);
+// Enable https if paths to key, cert, and ca files has been configured
+if (app.get('key') && app.get('cert') && app.get('ca')) {
+  server = https.createServer({
+    key: fs.readFileSync(path.resolve(__dirname, app.get('key'))),
+    cert: fs.readFileSync(path.resolve(__dirname, app.get('cert'))),
+    ca: fs.readFileSync(path.resolve(__dirname, app.get('ca')))
+  }, app);
+}
 
+// Otherwise fall back to regular http
+else {
+  server = http.createServer(app);
+}
+
+server.listen(port);
 app.setup(server);


### PR DESCRIPTION
Makes the ssl file paths configurable rather than hardcoded. Also allows one to
disable ssl entirely by simply setting any one of `key`, `cert`, or `ca` to
`null` (or any other falsey value).

Closes https://github.com/TimIsOverpowered/AngelThump/issues/17