### PR TITLE
bundle up client-side deps with browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ data/
 
 *.DS_Store
 .DS_Store
+
+public/bundle.js

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "node": ">= 0.12.0"
   },
   "scripts": {
+    "build": "buble < public/app.jsx | browserify -g uglifyify - | uglifyjs -cm > public/bundle.js",
     "test": "npm run jshint && npm run mocha",
     "jshint": "jshint src/. test/. --config",
     "start": "node src/",
@@ -27,9 +28,10 @@
     "compression": "^1.6.2",
     "cors": "^2.7.1",
     "ejs": "^2.4.2",
-    "feathers": "^2.0.1",
+    "feathers": "^2.0.3",
     "feathers-authentication": "^0.7.9",
-    "feathers-configuration": "^0.4.1",
+    "feathers-client": "^1.5.2",
+    "feathers-configuration": "^0.3.1",
     "feathers-errors": "^2.4.0",
     "feathers-hooks": "^1.5.4",
     "feathers-mongoose": "^3.6.1",
@@ -37,6 +39,8 @@
     "feathers-socketio": "^1.4.1",
     "mongoose": "^4.5.8",
     "passport": "^0.3.2",
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1",
     "request": "^2.72.0",
     "request-promise": "^4.1.1",
     "serve-favicon": "^2.3.0",
@@ -44,8 +48,12 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
+    "browserify": "^13.1.0",
+    "buble": "^0.15.2",
     "jshint": "^2.9.2",
     "mocha": "^3.0.1",
-    "request": "^2.74.0"
+    "request": "^2.74.0",
+    "uglify-js": "^2.7.3",
+    "uglifyify": "^3.0.2"
   }
 }

--- a/public/app.jsx
+++ b/public/app.jsx
@@ -1,5 +1,12 @@
+'use strict';
+
+const feathers = require('feathers-client');
+const React = require('react');
+const ReactDOM = require('react-dom');
+
 // Establish a Socket.io connection
 const socket = io();
+
 // Initialize our Feathers client application through Socket.io
 // with hooks and authentication.
 const app = feathers()
@@ -24,7 +31,7 @@ const Profile = React.createClass({
     });
   },
 
-  toggleStreamKey(){
+  toggleStreamKey() {
     this.setState({showStreamKey: !this.state.showStreamKey})
   },
 
@@ -34,8 +41,6 @@ const Profile = React.createClass({
 
   render() {
     const user = this.props.user;
-
-    // <a className="button" href="#" onClick={this.resetStreamKey}>Reset Stream Key</a>
 
     return <main className="container">
       <div className="row">
@@ -133,14 +138,6 @@ const ProfileApp = React.createClass({
     return {
       user: {}
     };
-  },
-
-  componentDidUpdate: function() {
-    // Whenever something happened, scroll to the bottom of the chat window
-    const node = this.getDOMNode().querySelector('.chat');
-    node.scrollTop = node.scrollHeight - node.clientHeight;
-
-
   },
 
   componentDidMount() {

--- a/public/profile.html
+++ b/public/profile.html
@@ -13,14 +13,8 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/chat.css">
 
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/core-js/2.1.4/core.min.js"></script>
-    <script src="//fb.me/react-0.14.7.min.js"></script>
-    <script src="//fb.me/react-dom-0.14.7.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.12.0/moment.js"></script>
-    <script src="//npmcdn.com/feathers-client@^1.0.0/dist/feathers.js"></script>
     <script src="/socket.io/socket.io.js"></script>
-    <script type="text/babel" src="app.jsx"></script>
+    <script src="bundle.js"></script>
   </head>
   <body>
   </body>


### PR DESCRIPTION
`npm run build` will now compile `public/app.jsx` into `public/bundle.js`. Preferably, before deploying, one should set the `NODE_ENV` environment variable like so:

``` shell
$ NODE_ENV=production npm run build
```

which will result in a lot of development code being removed from React, which cuts down a few dozen kilobytes from the bundle.

Improvements from here would be incorporating [`bundle-collapser`](https://github.com/substack/bundle-collapser), adding a `prestart` script for running `npm run build`, and a means of not minifying the bundle when we are in development environment.

Closes https://github.com/TimIsOverpowered/AngelThump/issues/24
